### PR TITLE
Retaining JDK 1.8, but reducing OWASP complaints, especially on log4j…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,13 +31,13 @@
     </developers>
     
     <properties>
-        <org.slf4j-version>1.7.26</org.slf4j-version>
-        <org.log4j-version>2.8.2</org.log4j-version>
+        <org.slf4j-version>2.0.7</org.slf4j-version>
+        <org.log4j-version>2.20.0</org.log4j-version>
         <java.version>1.8</java.version>
-        <jackson.version>2.9.10.1</jackson.version>
-        <commons.io.version>2.6</commons.io.version>
-        <guava.version>27.0.1-jre</guava.version>
-        <owasp.dependency.check.plugin.version>5.2.2</owasp.dependency.check.plugin.version>
+        <jackson.version>2.15.0</jackson.version>
+        <commons.io.version>2.11.0</commons.io.version>
+        <guava.version>31.1-jre</guava.version>
+        <owasp.dependency.check.plugin.version>8.2.1</owasp.dependency.check.plugin.version>
     </properties>
     <dependencies>
         <dependency>
@@ -112,7 +112,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.10</version>
+            <version>4.13.2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,6 @@
     </developers>
     
     <properties>
-        <org.slf4j-version>2.0.7</org.slf4j-version>
         <org.log4j-version>2.20.0</org.log4j-version>
         <java.version>1.8</java.version>
         <jackson.version>2.15.0</jackson.version>
@@ -40,11 +39,6 @@
         <owasp.dependency.check.plugin.version>8.2.1</owasp.dependency.check.plugin.version>
     </properties>
     <dependencies>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <version>${org.slf4j-version}</version>
-        </dependency>
         <!-- Binding for Log4J -->
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>


### PR DESCRIPTION
The branch name in this case can basically be ignored.  These changes reduce OWASP CVE complaints, especially log4j ones.  At this time, the latest version of guava does issue a CVE, but there is nothing newer.